### PR TITLE
Fix: Prevent filter tags from changing color with browser dark mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI - ESLint, Test & Build (All Must Pass)
 
 on:
   push:
-    branches: [main, develop, Yu, dev-test, color-bug-fix, 'feat/**']
+    branches: [main, develop, Yu, dev-test, color-bug-fix, fix-browser-color-mode-issue, 'feat/**']
   pull_request:
-    branches: [main, develop, Yu, dev-test, color-bug-fix, 'feat/**']
+    branches: [main, develop, Yu, dev-test, color-bug-fix, fix-browser-color-mode-issue, 'feat/**']
 
 jobs:
   ci:


### PR DESCRIPTION
## Problem

Filter tags (Food types and Tags) were changing color when the browser's appearance/dark mode changed, even when the user didn't toggle the in-app theme.

## Root Cause

1. `ThemeProvider` was using `prefers-color-scheme` media query to initialize theme, causing the app to automatically follow browser dark mode
2. Tag buttons had `dark:` Tailwind classes that would activate whenever `html.dark` was present

## Solution

### 1. Updated ThemeProvider (`src/lib/ThemeProvider.tsx`)
- Changed `getInitialTheme()` to ignore system `prefers-color-scheme`
- Now uses only `localStorage` with default fallback to `'light'`
- App theme is now controlled exclusively by the in-app toggle, not browser settings

### 2. Removed dark mode variants from filter tags (`src/app/page.tsx`)
- Removed all `dark:*` classes from Food types and Tags buttons
- Tags now maintain consistent colors regardless of theme:
  - Selected: `bg-black text-white border-black`
  - Unselected: `bg-white text-black border-gray-300 hover:bg-gray-100`

### 3. Updated tests (`src/lib/test/ThemeProvider.test.tsx`)
- Updated test expectations to match new behavior
- Tests now verify theme defaults to light when no saved preference exists
- Tests confirm system preference is ignored

## Testing

- ✅ All 225 Jest tests passing
- ✅ TypeScript type check passing
- ✅ Manual verification: tags no longer change color when browser appearance changes

## Files Changed

- `src/lib/ThemeProvider.tsx` - Updated theme initialization logic
- `src/app/page.tsx` - Removed dark mode classes from filter buttons
- `src/lib/test/ThemeProvider.test.tsx` - Updated test expectations
- `.github/workflows/ci.yml` - Added branch to CI triggers